### PR TITLE
Range slider changes

### DIFF
--- a/src/MudBlazor.Docs/Pages/Components/Slider/Examples/SliderRangeExample.razor
+++ b/src/MudBlazor.Docs/Pages/Components/Slider/Examples/SliderRangeExample.razor
@@ -1,10 +1,10 @@
 ﻿@namespace MudBlazor.Docs.Examples
 
-Lower Value: @value.ToString()
-Upper Value: @upperValue.ToString()
-<MudSlider @bind-Value="@value" @bind-UpperValue="@upperValue" Variant="Variant.Filled" ValueLabel="true" IsRangeSlider="true">Range</MudSlider>
+Lower Value: @_value.ToString()
+Upper Value: @_upperValue.ToString()
+<MudSlider @bind-Value="@_value" @bind-UpperValue="@_upperValue" Variant="Variant.Filled" ValueLabel="true" IsRangeSlider="true" >Range</MudSlider>
 
 @code {
-   public double value = 50.0;
-   public double upperValue = 75.0;
+   private int _value = 25;
+   private int _upperValue = 75;
 }

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -37,15 +37,18 @@
                @bind-value="@Text" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
 
         @SliderValueLabel(left, width, Value?.ToString())
-
-        <input class="mud-slider-input" aria-valuenow="@UpperValue" aria-valuemin="@_min" aria-valuemax="@_max" role="slider" @attributes="UserAttributes" type="range" min="@_min" max="@_max" step="@_step" disabled="@(Disabled || _userInvalidatedRange)"
-               @bind-Value="@UpperText" @bind-Value:event="@(Immediate ? "oninput" : "onchange")"/>
-
-        @if (ValueLabel)
+        
+        @if (IsRangeSlider)
         {
-            <div class="mud-slider-value-label" style="@($"left:{upperLeft}%;")">
-                @UpperValue?.ToString()
-            </div>
+            <input class="mud-slider-input" aria-valuenow="@UpperValue" aria-valuemin="@_min" aria-valuemax="@_max" role="slider" @attributes="UserAttributes" type="range" min="@_min" max="@_max" step="@_step" disabled="@(Disabled || _userInvalidatedRange)"
+                   @bind-value="@UpperText" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
+
+            @if (ValueLabel)
+            {
+                <div class="mud-slider-value-label" style="@($"left:{upperLeft}%;")">
+                    @UpperValue?.ToString()
+                </div>
+            }
         }
     </div>
 

--- a/src/MudBlazor/Components/Slider/MudSlider.razor
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor
@@ -10,61 +10,81 @@
 }
 
 <div class="@Classname" style="@Style">
-	@if (ChildContent != null)
-	{
-		<MudText Typo="Typo.body1">@ChildContent</MudText>
-	}
+    @if (ChildContent != null)
+    {
+        <MudText Typo="Typo.body1">@ChildContent</MudText>
+    }
 
     <div class="@(IsRangeSlider ? "mud-slider-container mud-range-container" : "mud-slider-container")">
 
-		@if (Variant == Variant.Filled)
+        @if (Variant == Variant.Filled)
         {
+            var marginTop = IsRangeSlider ? "0" : "22px";
+
             <div class="mud-slider-inner-container">
-                <div class="mud-slider-filled" style="@(IsRangeSlider ? $"width:{width}%; margin-left:{left}%; margin-top:22px;" : $"width:{width}%;")"></div>
-			</div>
-		}
-		@if (TickMarks)
-		{
-			<div class="mud-slider-inner-container">
-				<div class="mud-slider-tickmarks">
-					@for (int i = 0; i < _tickMarkCount; i++)
-					{
-						int current = i;
-
-						<div class="d-flex flex-column relative">
-							<span class="mud-slider-track-tick" />
-							@if (TickMarkLabels != null && current < TickMarkLabels.Length)
-							{
-								<MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
-							}
-						</div>
-					}
-				</div>
-			</div>
-		}
-
-		<input class="mud-slider-input" aria-valuenow="@Value" aria-valuemin="@_min" aria-valuemax="@_max" role="slider" @attributes="UserAttributes" type="range" min="@_min" max="@_max" step="@_step" disabled="@Disabled"
-            @bind-value="@Text" @bind-value:event="@(Immediate ? "oninput" : "onchange")" @onchange="(() => EvaluateValues(true))" />
-        
-        @if (ValueLabel)
-        {
-            <div class="mud-slider-value-label" style="@(IsRangeSlider ? $"left:{left}%;" : $"left:{width}%;" )">
-                @Value?.ToString()
+                <div class="mud-slider-filled" style="@(IsRangeSlider ? $"width:{width}%; margin-left:{left}%; margin-top:{marginTop};" : $"width:{width}%;")"></div>
             </div>
         }
 
-        @if(IsRangeSlider)
+        @if (TickMarks)
         {
-            <input class="mud-slider-input" aria-valuenow="@UpperValue" aria-valuemin="@_min" aria-valuemax="@_max" role="slider" @attributes="UserAttributes" type="range" min="@_min" max="@_max" step="@_step" disabled="@Disabled"
-            @bind-UpperValue="@UpperText" @bind-UpperValue:event="@(Immediate ? "oninput" : "onchange")" @onchange="(() => EvaluateValues(false))" />
-            
-            @if (ValueLabel)
-            {
-                <div class="mud-slider-value-label" style="@($"left:{upperLeft}%;")">
-                    @UpperValue?.ToString()
-                </div>
-            }
+            <div class="mud-slider-inner-container">
+                @SliderTickMarks()
+            </div>
         }
-	</div>
+
+        <input class="mud-slider-input" aria-valuenow="@Value" aria-valuemin="@_min" aria-valuemax="@_max" role="slider" @attributes="UserAttributes" type="range" min="@_min" max="@_max" step="@_step" disabled="@(Disabled || _userInvalidatedRange)"
+               @bind-value="@Text" @bind-value:event="@(Immediate ? "oninput" : "onchange")" />
+
+        @SliderValueLabel(left, width, Value?.ToString())
+
+        <input class="mud-slider-input" aria-valuenow="@UpperValue" aria-valuemin="@_min" aria-valuemax="@_max" role="slider" @attributes="UserAttributes" type="range" min="@_min" max="@_max" step="@_step" disabled="@(Disabled || _userInvalidatedRange)"
+               @bind-Value="@UpperText" @bind-Value:event="@(Immediate ? "oninput" : "onchange")"/>
+
+        @if (ValueLabel)
+        {
+            <div class="mud-slider-value-label" style="@($"left:{upperLeft}%;")">
+                @UpperValue?.ToString()
+            </div>
+        }
+    </div>
 
 </div>
+
+@if (_userInvalidatedRange)
+{
+    _userInvalidatedRange = false;
+    StateHasChanged();
+}
+
+@code
+{
+    private RenderFragment SliderValueLabel(string left, string width, string value)
+    {
+        @if (ValueLabel)
+        {
+            return @<div class="mud-slider-value-label" style="@(IsRangeSlider ? $"left:{left}%;" : $"left:{width}%;")">
+                       @value
+                   </div>;
+        }
+        return null;
+    }
+
+    private RenderFragment SliderTickMarks()
+    {
+        return @<div class="mud-slider-tickmarks">
+                   @for (int i = 0; i < _tickMarkCount; i++)
+                   {
+                       int current = i;
+
+                       <div class="d-flex flex-column relative">
+                           <span class="mud-slider-track-tick"/>
+                           @if (TickMarkLabels != null && current < TickMarkLabels.Length)
+                           {
+                               <MudText Class="mud-slider-track-tick-label" Typo="Typo.body2">@TickMarkLabels[current]</MudText>
+                           }
+                       </div>
+                   }
+               </div>;
+    }
+}

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -113,7 +113,7 @@ namespace MudBlazor
                     return;
                 }
 
-                if (IsRangeSlider && Convert.ToDecimal(d) >= Convert.ToDecimal(UpperValue))
+                if (IsRangeSlider && _upperValue != null && Convert.ToDecimal(d) >= Convert.ToDecimal(UpperValue))
                 {
                     _userInvalidatedRange = true;
                     return;
@@ -137,7 +137,7 @@ namespace MudBlazor
                     return;
                 }
 
-                if (IsRangeSlider && Convert.ToDecimal(d) <= Convert.ToDecimal(Value))
+                if (IsRangeSlider && _value != null && Convert.ToDecimal(d) <= Convert.ToDecimal(Value))
                 {
                     _userInvalidatedRange = true;
                     return;

--- a/src/MudBlazor/Components/Slider/MudSlider.razor.cs
+++ b/src/MudBlazor/Components/Slider/MudSlider.razor.cs
@@ -24,6 +24,14 @@ namespace MudBlazor
         protected bool _isRangeSlider = false;
         protected string? _upperValue;
 
+
+        /// <summary>
+        /// This will be set to true if the user sets the lower value to be greater than the upper value
+        /// or vice versa. It will detach the user from the slider and then the value will be reset
+        /// in the razor file.
+        /// </summary>
+        private bool _userInvalidatedRange;
+
         /// <summary>
         /// If this is a Range Slider
         /// </summary>
@@ -105,6 +113,12 @@ namespace MudBlazor
                     return;
                 }
 
+                if (IsRangeSlider && Convert.ToDecimal(d) >= Convert.ToDecimal(UpperValue))
+                {
+                    _userInvalidatedRange = true;
+                    return;
+                }
+
                 _value = d;
                 ValueChanged.InvokeAsync(value);
             }
@@ -120,6 +134,12 @@ namespace MudBlazor
                 var d = Converter.Set(value);
                 if (_upperValue == d)
                 {
+                    return;
+                }
+
+                if (IsRangeSlider && Convert.ToDecimal(d) <= Convert.ToDecimal(Value))
+                {
+                    _userInvalidatedRange = true;
                     return;
                 }
 
@@ -144,6 +164,11 @@ namespace MudBlazor
                 {
                     return;
                 }
+                if (IsRangeSlider && Convert.ToDecimal(value) >= Convert.ToDecimal(UpperValue))
+                {
+                    _userInvalidatedRange = true;
+                    return;
+                }
 
                 _value = value;
                 ValueChanged.InvokeAsync(Value);
@@ -160,24 +185,14 @@ namespace MudBlazor
                     return;
                 }
 
+                if (IsRangeSlider && Convert.ToDecimal(value) <= Convert.ToDecimal(Value))
+                {
+                    _userInvalidatedRange = true;
+                    return;
+                }
+
                 _upperValue = value;
                 UpperValueChanged.InvokeAsync(UpperValue);
-            }
-        }
-
-        protected void EvaluateValues(bool isMinEdited)
-        {
-            if (IsRangeSlider)
-            {
-                if (!isMinEdited && Convert.ToDecimal(UpperValue) < Convert.ToDecimal(Value))
-                {
-                    Value = UpperValue;
-                }
-
-                if (isMinEdited && Convert.ToDecimal(Value) > Convert.ToDecimal(UpperValue))
-                {
-                    UpperValue = Value;
-                }
             }
         }
 

--- a/src/MudBlazor/Styles/components/_slider.scss
+++ b/src/MudBlazor/Styles/components/_slider.scss
@@ -209,9 +209,10 @@
         left: 0;
     }
 
-    .mud-range-container .mud-slider-input {
+    .mud-range-container .mud-slider-input:last-of-type {
         position: absolute;
         pointer-events: none;
+        top: 0;
     }
 
     .mud-range-container input[type=range]::-webkit-slider-thumb {


### PR DESCRIPTION
This fixes a couple issues and changes functionality a little bit. 

#### New Functionality
Rather than letting the two ranges slide over each other and swapping the value, I made it so it just stops the interaction altogether when the user attempts to add a slider into a invalid position.

#### Fixes
- Ticks work
- Size works
- Initializes values and range correctly

#### Know Limitations
- It literally stops the interaction, users will have to let go and click again if they move one of the values into a invalid location.
- Because of the issue above, if users move the slider very fast, it can cause the interaction to stop with the boundaries more than one step apart. You can still click again and move them closer together. Just created a little confusion.
- When you click on the line it will always move the lower boundary. This works as you'd expect if the click location is before the upper value - the lower boundary will move to the click location. But if you click to the right of the upper value boundary, it will attempt to move the lower boundary, fail, and nothing will happen; it doesn't break. It still functions after such event
  - Only fix I could think of is a javascript mouse observer to adjust the z-index of the 2 input ranges based on the position of the mouse relative to the upper boundary.

Also, I noticed that vertical and size do not work together. It was also broken before this branch.